### PR TITLE
Exclude some types from 4.0/4.5 profile

### DIFF
--- a/class/PresentationCore/Assembly/AssemblyInfo.cs
+++ b/class/PresentationCore/Assembly/AssemblyInfo.cs
@@ -36,6 +36,7 @@ using System.Security.Permissions;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Windows.Input;
 using System.Windows.Markup;
 
 // General Information about the PresentationCore assembly
@@ -101,3 +102,11 @@ using System.Windows.Markup;
 [assembly: XmlnsDefinition ("http://schemas.microsoft.com/xps/2005/06", "System.Windows.Automation")]
 [assembly: XmlnsDefinition ("http://schemas.microsoft.com/xps/2005/06", "System.Windows.Media.Effects")]
 [assembly: XmlnsDefinition ("http://schemas.microsoft.com/xps/2005/06", "System.Windows.Media.Imaging")]
+
+#if NET_4_0
+[assembly: TypeForwardedTo (typeof(IUriContext))]
+#endif
+
+#if NET_4_5
+[assembly: TypeForwardedTo (typeof(ICommand))]
+#endif

--- a/class/PresentationCore/System.Windows.Input/ICommand.cs
+++ b/class/PresentationCore/System.Windows.Input/ICommand.cs
@@ -23,6 +23,8 @@
 //	Chris Toshok (toshok@ximian.com)
 //
 
+#if !NET_4_5
+
 using System;
 
 namespace System.Windows.Input {
@@ -34,3 +36,5 @@ namespace System.Windows.Input {
 	}
 
 }
+
+#endif

--- a/class/PresentationCore/System.Windows.Markup/IUriContext.cs
+++ b/class/PresentationCore/System.Windows.Markup/IUriContext.cs
@@ -23,7 +23,7 @@
 //	Chris Toshok (toshok@novell.com)
 //
 
-#if !NET_4_0 && !NET_4_5
+#if !NET_4_0
 
 using System;
 

--- a/class/PresentationFramework/Assembly/AssemblyInfo.cs
+++ b/class/PresentationFramework/Assembly/AssemblyInfo.cs
@@ -108,3 +108,11 @@ using System.Windows.Markup;
 [assembly: XmlnsDefinition ("http://schemas.microsoft.com/xps/2005/06", "System.Windows.Media.Animation")]
 
 [assembly: XmlnsDefinition ("http://schemas.microsoft.com/xps/2005/06/documentstructure", "System.Windows.Documents.DocumentStructures")]
+
+#if NET_4_0
+[assembly: TypeForwardedTo (typeof(IProvideValueTarget))]
+[assembly: TypeForwardedTo (typeof(ArrayExtension))]
+[assembly: TypeForwardedTo (typeof(NullExtension))]
+[assembly: TypeForwardedTo (typeof(StaticExtension))]
+[assembly: TypeForwardedTo (typeof(TypeExtension))]
+#endif

--- a/class/PresentationFramework/System.Windows.Markup/ArrayExtension.cs
+++ b/class/PresentationFramework/System.Windows.Markup/ArrayExtension.cs
@@ -20,6 +20,8 @@
 // Copyright (c) 2008 Novell, Inc. (http://www.novell.com)
 //
 
+#if !NET_4_0
+
 using System;
 using System.Collections;
 using System.ComponentModel;
@@ -73,3 +75,5 @@ namespace System.Windows.Markup {
 	}
 
 }
+
+#endif

--- a/class/PresentationFramework/System.Windows.Markup/IProvideValueTarget.cs
+++ b/class/PresentationFramework/System.Windows.Markup/IProvideValueTarget.cs
@@ -20,6 +20,8 @@
 // Copyright (c) 2008 Novell, Inc. (http://www.novell.com)
 //
 
+#if !NET_4_0
+
 namespace System.Windows.Markup {
 
 	public interface IProvideValueTarget {
@@ -27,3 +29,5 @@ namespace System.Windows.Markup {
 		object TargetObject { get; }
 	}
 }
+
+#endif

--- a/class/PresentationFramework/System.Windows.Markup/NullExtension.cs
+++ b/class/PresentationFramework/System.Windows.Markup/NullExtension.cs
@@ -20,6 +20,8 @@
 // Copyright (c) 2008 Novell, Inc. (http://www.novell.com)
 //
 
+#if !NET_4_0
+
 using System;
 
 namespace System.Windows.Markup {
@@ -37,3 +39,5 @@ namespace System.Windows.Markup {
 		}
 	}
 }
+
+#endif

--- a/class/PresentationFramework/System.Windows.Markup/StaticExtension.cs
+++ b/class/PresentationFramework/System.Windows.Markup/StaticExtension.cs
@@ -20,6 +20,8 @@
 // Copyright (c) 2008 Novell, Inc. (http://www.novell.com)
 //
 
+#if !NET_4_0
+
 using System;
 using System.ComponentModel;
 using System.Reflection;
@@ -87,3 +89,6 @@ namespace System.Windows.Markup {
 	}
 
 }
+
+#endif
+

--- a/class/PresentationFramework/System.Windows.Markup/TypeExtension.cs
+++ b/class/PresentationFramework/System.Windows.Markup/TypeExtension.cs
@@ -20,6 +20,8 @@
 // Copyright (c) 2008 Novell, Inc. (http://www.novell.com)
 //
 
+#if !NET_4_0
+
 using System;
 using System.ComponentModel;
 
@@ -80,3 +82,5 @@ namespace System.Windows.Markup {
 		string typeName;
 	}
 }
+
+#endif


### PR DESCRIPTION
Those types have been promoted to various dlls in mono.
